### PR TITLE
Feature.dockerize

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM django:onbuild
+RUN pip install -r requirements/dev.txt
+ENV DJANGO_SETTINGS_MODULE dicodigital.settings
+ENV DATABASE_URL sqlite:////usr/src/app/dicodigital.db
+ENV DEBUG True
+WORKDIR /usr/src/app
+RUN python manage.py migrate && python manage.py createsuperuser && python manage.py loaddata fixtures/users.json fixtures/words.json fixtures/definitions.json
+ENTRYPOINT [ "python", "manage.py", "runserver_plus" ]
+CMD [ "0.0.0.0:8000" ]

--- a/README.md
+++ b/README.md
@@ -57,3 +57,16 @@ Run the magic:
 ```bash
 ./manage.py runserver_plus
 ```
+
+## With Docker
+
+To run a container with everything in local, there is an image for that
+from the docker hub [https://hub.docker.com/u/dicodigital](https://hub.docker.com/u/dicodigital).
+
+Run the container with:
+
+```
+docker run --rm --name dicodigital-api -p 8000:8000 dicodigital/dicodigital-api
+```
+
+To build a new images, run `docker build -t dicodigital-api .`

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
--r requirements/base.txt
-
 static
 gunicorn
 psycopg2


### PR DESCRIPTION
J'ai ajouté un Dockerfile avec lequel j'ai créé une image pushée sur le hub.docker.com : https://hub.docker.com/u/dicodigital.

Il faut garder ce Dockerfile au chaud pour builder les prochaines versions de l'api. On pourrait même automatiser les builds avec quelques chose comme ça : https://docs.docker.com/docker-hub/builds/.

Et donc pour faire tourner l'api en local sans se poser de question, il faut faire quelque chose comme ça (avec ou sans options pratiques) :

```
docker run dicodigital/dicodigital-api
```
